### PR TITLE
增加单独设置抽卡分析`Cookie`的功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ header+draw_analysis_history使用历史数据分析
 
 ## 3.1返回图片出现字体乱码
 
-出现问题原因为linux中文字体缺失， 可参考 [此文章](https://www.cnblogs.com/helios-fz/p/13706157.html)安装字体后  重启bot
+出现问题原因为linux中文字体缺失， 可参考 [此文章](https://www.cnblogs.com/helios-fz/p/13706157.html)安装字体后 重启bot
 
 docker部署可参考[此issue](https://github.com/wickedll/genshin_draw_analysis/issues/5) 安装字体
 
 ## 3.2提示visit too frequently
 
-此为mhy接口限制 某一时间内请求次数超过最大限制，此时只需将draw_analysis.ts里面的sleep延时数值调高一点即可（49行 调500-700 不行就再调大一点） [issue](https://github.com/wickedll/genshin_draw_analysis/issues/4)
+此为mhy接口限制 某一时间内请求次数超过最大限制，此时只需将draw_analysis.ts里面的sleep延时数值调高一点即可（49行 调500-700
+不行就再调大一点） [issue](https://github.com/wickedll/genshin_draw_analysis/issues/4)
 
 ## 3.3提示authkey timeout或authkey error
 
@@ -30,6 +31,8 @@ authkey过期或有误，重新获取url设置。
 
 # 4.更新日志
 
+- 在设置抽卡分析链接的指令中增加单独设置抽卡分析`Cookie`的功能，可以与私人服务的`Cookie`独立互不影响，分析时兼容私人服务的`Cookie`优先用单独设置的`Cookie`，没有则使用私人服务中的`Cookie`。
+  2022/09/22
 - 修复分析指令单个参数未生效的问题; 解决`login_ticket`频繁过期需要经常换`Cookie`的问题。2022/09/22
 - 抽卡分析指令增加指定私人服务序号的功能（之前与样式公用值，算是个小 bug ）。2022/09/22
 - 修复缓存中的过期链接导致无法自动生成新的 AuthKey 的问题 2022/09/21

--- a/achieves/draw_url.ts
+++ b/achieves/draw_url.ts
@@ -1,10 +1,58 @@
 import { InputParameter } from "@modules/command";
+import { cookie2Obj } from "#genshin_draw_analysis/util/util";
+import { getBaseInfo } from "#genshin/utils/api";
+import * as ApiType from "#genshin/types";
+import { ErrorMsg } from "#genshin/utils/promise";
 
 
 export async function main(
-	{ sendMessage, messageData, redis }: InputParameter
+	{ sendMessage, messageData, redis, logger }: InputParameter
 ): Promise<void> {
 	const { user_id: userID, raw_message: msg } = messageData;
+	if ( !msg.includes( "https://" ) ) {
+		// 按cookie处理
+		try {
+			const { login_ticket, login_uid } = cookie2Obj( msg );
+			if ( !login_ticket ) {
+				await sendMessage( 'Cookie缺少 login_ticket 字段，请到 https://user.mihoyo.com/ 页面登录后获取Cookie' );
+				return;
+			}
+			
+			const { retcode, message, data } = await getBaseInfo( login_uid, msg );
+			
+			if ( !ApiType.isBBS( data ) ) {
+				await sendMessage( ErrorMsg.UNKNOWN );
+				return;
+			} else if ( retcode !== 0 ) {
+				await sendMessage( ErrorMsg.FORM_MESSAGE + message );
+				return;
+			} else if ( !data.list || data.list.length === 0 ) {
+				await sendMessage( ErrorMsg.NOT_FOUND );
+				return;
+			}
+			
+			const genshinInfo: ApiType.Game | undefined = data.list.find( el => el.gameId === 2 );
+			if ( !genshinInfo ) {
+				await sendMessage( ErrorMsg.NOT_FOUND );
+				return;
+			}
+			
+			const uid: string = genshinInfo.gameRoleId;
+			const server: string = genshinInfo.region;
+			
+			await redis.setHash( `genshin_gacha.cookie.${ userID }`, {
+				uid,
+				cookie: msg,
+				server,
+				mysID: login_uid
+			} );
+			await sendMessage( "米游社通行证Cookie设置成功" );
+			return;
+		} catch ( error ) {
+			logger.error( <string>error );
+			await sendMessage( <string>error );
+		}
+	}
 	let api_url = 'https://hk4e-api.mihoyo.com/event/gacha_info/api/getGachaLog?';
 	try {
 		if ( msg.indexOf( "getGachaLog?" ) > -1 ) {

--- a/init.ts
+++ b/init.ts
@@ -26,11 +26,11 @@ export let pageFunction: PageFunction = async ( page: puppeteer.Page ) => {
 const draw_url: OrderConfig = {
 	type: "order",
 	cmdKey: "genshin.draw.analysis.url",
-	desc: [ "原神抽卡记录URL设置", "(记录URL)" ],
+	desc: [ "原神抽卡记录URL设置", "(记录URL|通行证Cookie)" ],
 	headers: [ "su" ],
 	regexps: [ ".+" ],
 	main: "achieves/draw_url",
-	detail: "设置抽卡记录url",
+	detail: "设置抽卡记录url或者米游社通行证的Cookie",
 	scope: MessageScope.Private,
 	ignoreCase: false
 }
@@ -40,7 +40,8 @@ const draw_analysis: OrderConfig = {
 	cmdKey: "genshin.draw.analysis",
 	desc: [ "抽卡分析", "(私人服务序号) (样式)" ],
 	headers: [ "da" ],
-	detail: "使用设置的抽卡记录URL重新拉取数据并合并历史数据分析, 1: pc样式,2: phone样式，如果只传一个参数优先匹配服务序号。",
+	detail: "使用设置的抽卡记录URL重新拉取数据并合并历史数据分析, 1: pc样式,2: phone样式，如果只传一个参数优先匹配服务序号。\n" +
+		"如果设置了抽卡分析的Cookie将优先使用抽卡分析的Cookie，否则将使用私人服务中的Cookie",
 	regexps: [ "(\\d+)?", "(\\d+)?" ],
 	main: "achieves/draw_analysis"
 };


### PR DESCRIPTION
- 给设置抽卡链接指令增加设置通行证Cookie的功能，与私人服务的Cookie分开，避免与私人服务中的签到等功能互相影响。
- 分析指令兼容私人服务的Cookie，优先使用单独设置的Cookie。